### PR TITLE
Fix meta charset typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta charset="UTF--8">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>合同会社せいぎょばん - Factory Automation Experts</title>
     <style>


### PR DESCRIPTION
## Summary
- correct the charset meta declaration to use UTF-8 so Japanese text renders correctly

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c9febeacf883299a7a74660e84e818