### PR TITLE
Move Google Fonts import to top of style block

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>合同会社せいぎょばん - Factory Automation Experts</title>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&family=Poppins:wght@600&display=swap');
+
         /* --- Reset & Basic Styles --- */
         :root {
             --primary-color: #007BFF; /* Accent color */
@@ -15,8 +17,6 @@
             --shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
             --border-radius: 8px;
         }
-
-        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&family=Poppins:wght@600&display=swap');
 
         * {
             margin: 0;


### PR DESCRIPTION
## Summary
- move the Google Fonts `@import` statement to the start of the inline style block so fonts load before other rules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9febfd22083298a6fa6c610744607